### PR TITLE
RTL support for arabic language breaking the project timeline history…

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -1330,6 +1330,12 @@ html {
         left: 20px;
     }
 
+    [dir="rtl"] .timeline::before {
+        left: auto;
+        right: 20px;
+        transform: translateX(50%);
+    }
+
     .timeline-item {
         grid-template-columns: 40px 1fr;
         gap: 20px;

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -53,6 +53,16 @@ def test_language_switcher_is_present(client) -> None:
     assert 'id="languageSwitcher"' in html
 
 
+def test_mobile_rtl_timeline_alignment_rule_exists(client) -> None:
+    response = client.get("/static/style.css")
+    stylesheet = response.data.decode("utf-8")
+
+    assert response.status_code == 200
+    assert '[dir="rtl"] .timeline::before' in stylesheet
+    assert "right: 20px;" in stylesheet
+    assert "transform: translateX(50%);" in stylesheet
+
+
 def test_asset_version_query_param_is_stable(client) -> None:
     first_response = client.get("/?lang=en")
     second_response = client.get("/?lang=en")

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -56,10 +56,16 @@ def test_language_switcher_is_present(client) -> None:
 def test_mobile_rtl_timeline_alignment_rule_exists(client) -> None:
     response = client.get("/static/style.css")
     stylesheet = response.data.decode("utf-8")
+    selector = '[dir="rtl"] .timeline::before'
 
     assert response.status_code == 200
-    assert '[dir="rtl"] .timeline::before' in stylesheet
-    assert "right: 20px;" in stylesheet
+    assert selector in stylesheet
+
+    rtl_rule_text = stylesheet.split(selector, 1)[1]
+    _, _, rtl_rule_body_with_suffix = rtl_rule_text.partition("{")
+    rtl_rule_body, _, _ = rtl_rule_body_with_suffix.partition("}")
+
+    assert "right: 20px;" in rtl_rule_body
     assert "transform: translateX(50%);" in stylesheet
 
 


### PR DESCRIPTION
## Summary

Describe the goal of this PR and what changed.

## Related Issue

Closes - #15 


## Change Type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Tests/CI

## Checklist
- [x] I ran tests locally (`pytest`)
- [x] I ran lint checks locally (`flake8`, `black --check`)
- [x] I updated docs/config examples if needed
- [x] I added or updated tests for behavior changes
- [x] I verified multilingual/dark mode behavior for UI changes

## Screenshots (if UI change)

Add before/after screenshots.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Right-to-Left (RTL) language support for the timeline component, ensuring decorative elements and alignment render correctly in RTL layouts.

* **Tests**
  * Added a test that verifies the presence and correctness of RTL timeline styling to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->